### PR TITLE
Import SoapFault from the global namespace

### DIFF
--- a/src/Zuora/Soap/API.php
+++ b/src/Zuora/Soap/API.php
@@ -2,6 +2,7 @@
 
 use Exception;
 use SoapClient;
+use SoapFault;
 use SoapHeader;
 
 /**


### PR DESCRIPTION
In API.php SoapFault is not imported from the global namespace. This means, SoapFault could have never been properly caught and delegated to ZuoraFault